### PR TITLE
add 'branch' to build info

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -54,6 +54,7 @@ export const UnpluginInfo = createUnplugin<Options | undefined>((option) => {
           `export const github = ${JSON.stringify(github ?? null)}`,
           gen('sha'),
           gen('abbreviatedSha'),
+          gen('branch'),
           gen('tag'),
           gen('committer'),
           gen('committerDate'),


### PR DESCRIPTION
### Description

Exposes `branch` in build info that is provided by `git-repo-info`.