### PR TITLE
feat: export build info to global in example and deploy to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0 # to fetch all history
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2.4.0
@@ -34,3 +40,14 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Upload pages artifacts
+        # https://github.com/actions/upload-pages-artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'examples/vite/dist'
+
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        # https://github.com/actions/deploy-pages
+        uses: actions/deploy-pages@v4

--- a/examples/vite/index.html
+++ b/examples/vite/index.html
@@ -18,6 +18,11 @@
         font-style: normal;
       }
 
+      a {
+        color: #0070f3;
+        text-decoration: none;
+      }
+
       #app {
         display: flex;
         flex-direction: column;

--- a/examples/vite/main.ts
+++ b/examples/vite/main.ts
@@ -19,9 +19,7 @@ import { name, version } from '~build/package';
 
 import { format } from 'date-fns';
 
-console.log('Build time:', now);
-
-const buildTime = document.querySelector('.container') as HTMLElement;
+const buildTime = document.querySelector<HTMLElement>('.container')!;
 
 function append(key: string, value: string | number | null) {
   const p = document.createElement('div');
@@ -34,6 +32,11 @@ function append(key: string, value: string | number | null) {
   p.appendChild(span2);
   buildTime.appendChild(p);
 }
+
+const h1 = document.createElement('h1');
+// use caution with `innerHTML`
+h1.innerHTML = `<a href="${github}" target="_blank">unplugin-info<a>`;
+buildTime.appendChild(h1);
 
 append('Build time: ', format(now, 'yyyy-MM-dd hh:mm'));
 append('CI: ', CI ? CI : 'Not a CI env');
@@ -54,3 +57,6 @@ append('Message: ', message);
 
 append('Package name: ', name);
 append('Package version: ', version);
+append('', '');
+
+append('You can also open console and play around with it.', '');

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "playground",
+  "name": "unplugin-info-vite-demo",
   "version": "0.7.2",
   "private": "true",
   "type": "module",

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite';
 import BuildInfo from 'unplugin-info/vite';
 
 export default defineConfig({
+  base: './',
   plugins: [BuildInfo({ meta: { message: 'This is set from vite.config.ts' } })]
 });


### PR DESCRIPTION
This pull request includes the following changes:

- Export build info to global in vite example
- Deployed to GitHub Pages

You can view the example page at https://lawvs.github.io/unplugin-info/

Before merging, make sure to update the GitHub page setting.

<img width="735" alt="Screenshot 2024-01-26 at 04 28 41" src="https://github.com/yjl9903/unplugin-info/assets/18554747/faec4c0e-b623-42aa-ab20-6e33d916ef8d">

