### PR TITLE
fix: export build info to global in example

### DIFF
--- a/examples/vite/main.ts
+++ b/examples/vite/main.ts
@@ -18,6 +18,7 @@ import { name, version } from '~build/package';
 import { isCI, name as ciName } from '~build/ci';
 
 import { format } from 'date-fns';
+import './playground';
 
 const buildTime = document.querySelector<HTMLElement>('.container')!;
 

--- a/examples/vite/playground.ts
+++ b/examples/vite/playground.ts
@@ -1,0 +1,23 @@
+import * as ci from '~build/ci';
+import * as git from '~build/git';
+import * as info from '~build/info';
+import * as meta from '~build/meta';
+import * as packageInfo from '~build/package';
+import time from '~build/time';
+
+// poor man's unwrap
+const unwrapModule = <T>(obj: T): T => JSON.parse(JSON.stringify(obj));
+
+const buildInfo = {
+  info: unwrapModule(info),
+  git: unwrapModule(git),
+  ci: unwrapModule(ci),
+  meta: unwrapModule(meta),
+  package: unwrapModule(packageInfo),
+  time
+};
+
+(globalThis as any).buildInfo = buildInfo;
+
+console.log('You can access build info from `buildInfo` variable.');
+console.log(buildInfo);


### PR DESCRIPTION
I forgot to commit it in https://github.com/yjl9903/unplugin-info/pull/513